### PR TITLE
Optimised "showing time" python examples

### DIFF
--- a/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
@@ -72,6 +72,9 @@ try:
     image_old = epd.getbuffer(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54_V2_test.py
@@ -71,6 +71,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54_test.py
@@ -68,6 +68,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V2_test.py
@@ -72,6 +72,9 @@ try:
     epd.init(epd.PART_UPDATE)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((120, 80, 220, 105), fill = 255)
         time_draw.text((120, 80), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.displayPartial(epd.getbuffer(time_image))

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V3_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V3_test.py
@@ -70,6 +70,9 @@ try:
     epd.displayPartBaseImage(epd.getbuffer(time_image))
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((120, 80, 220, 105), fill = 255)
         time_draw.text((120, 80), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.displayPartial(epd.getbuffer(time_image))

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V4_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V4_test.py
@@ -110,6 +110,9 @@ try:
     epd.displayPartBaseImage(epd.getbuffer(time_image))
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((120, 80, 220, 105), fill = 255)
         time_draw.text((120, 80), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.displayPartial(epd.getbuffer(time_image))

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_test.py
@@ -70,6 +70,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((120, 80, 220, 105), fill = 255)
         time_draw.text((120, 80), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.display(epd.getbuffer(time_image))

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13d_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13d_test.py
@@ -65,6 +65,8 @@ try:
     # time_draw = ImageDraw.Draw(time_image)
     # num = 0
     # while (True):
+        # current_time = time.time()
+        # time.sleep(int(current_time) + 1 - current_time)
         # time_draw.rectangle((10, 10, 120, 50), fill = 255)
         # time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         # newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in66_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in66_test.py
@@ -81,6 +81,9 @@ try:
     time_draw = ImageDraw.Draw(Limage)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 210, 120, 250), fill = 255)
         time_draw.text((10, 210), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.display(epd.getbuffer(Limage))

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in7_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in7_V2_test.py
@@ -93,6 +93,9 @@ try:
     # draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         draw.rectangle((10, 110, 120, 150), fill = 255)
         draw.text((10, 110), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         newimage = Himage.crop([10, 110, 120, 150])

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9_V2_test.py
@@ -83,6 +83,9 @@ try:
     epd.display_Base(epd.getbuffer(time_image))
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9_test.py
@@ -82,6 +82,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9d_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9d_test.py
@@ -83,6 +83,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         newimage = time_image.crop([10, 10, 120, 50])

--- a/RaspberryPi_JetsonNano/python/examples/epd_3in7_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_3in7_test.py
@@ -91,6 +91,9 @@ try:
     time_draw = ImageDraw.Draw(time_image)
     num = 0
     while (True):
+        current_time = time.time()
+        time.sleep(int(current_time) + 1 - current_time)
+        
         time_draw.rectangle((10, 10, 120, 50), fill = 255)
         time_draw.text((10, 10), time.strftime('%H:%M:%S'), font = font24, fill = 0)
         epd.display_1Gray(epd.getbuffer(time_image))


### PR DESCRIPTION
During the "showing time" python examples, the e-Paper Displays refresh as often as possible. This causes the following issues:
- It does not make sense to refresh the display if the text on is has not changed.
- The seconds don't appear to be equally long because of misalignment of refresh times.

I added a wait before refreshing the screen, that always waits until the next full second. This solves all above mentioned issues.

I tested this on the epd2in13_V3 successfully. I have not tested it on other displays as I do not have them available.
I adjusted this on every file in the `RaspberryPi_JetsonNano/python/examples/` folder where I found a "showing time" section.