### PR TITLE
Detecting Raspberry Pi check, compatible with October 2023 Raspberry Pi OS

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -230,7 +230,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
+if os.path.exists('/etc/rpi-issue'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,6 +31,8 @@ import os
 import logging
 import sys
 import time
+from pathlib import Path
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +232,19 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if os.path.exists('/etc/rpi-issue'):
+
+
+def is_raspberry_pi():
+    CPUINFO_PATH = Path("/proc/cpuinfo")
+
+    if not CPUINFO_PATH.exists():
+        return False
+    with open(CPUINFO_PATH) as f:
+        cpuinfo = f.read()
+    return re.search(r"^Model\s*:\s*Raspberry Pi", cpuinfo, flags=re.M) is not None
+
+
+if is_raspberry_pi():
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -235,6 +235,7 @@ class SunriseX3:
 
 
 def is_raspberry_pi():
+    # https://raspberrypi.stackexchange.com/a/139704/540
     CPUINFO_PATH = Path("/proc/cpuinfo")
 
     if not CPUINFO_PATH.exists():


### PR DESCRIPTION
Issue https://github.com/waveshareteam/e-Paper/issues/306 

In the latest Raspberry Pi OS (October 2023) the file `/sys/bus/platform/drivers/gpiomem-bcm2835` no longer exists, so the epdconfig code tries to execute JetsonNano() code on Raspberry Pi. 

In this PR the code is checking `/proc/cpuinfo` for the `Model:` matching `Raspberry Pi`. This should work across multiple Raspberry Pi OS versions. 