### PR TITLE
Fix case of header files for Arduino IDE

### DIFF
--- a/Arduino/epd1in64g/epdif.cpp
+++ b/Arduino/epd1in64g/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd1in64g/epdif.h
+++ b/Arduino/epd1in64g/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd2in13d/epd2in13d.cpp
+++ b/Arduino/epd2in13d/epd2in13d.cpp
@@ -28,7 +28,7 @@
 #
 ******************************************************************************/
 #include "epd2in13d.h"
-#include <arduino.h>
+#include <Arduino.h>
 /**
  * full screen update LUT
 **/

--- a/Arduino/epd2in36g/epdif.cpp
+++ b/Arduino/epd2in36g/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd2in36g/epdif.h
+++ b/Arduino/epd2in36g/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd3in0g/epdif.cpp
+++ b/Arduino/epd3in0g/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd3in0g/epdif.h
+++ b/Arduino/epd3in0g/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd4in37g/epdif.cpp
+++ b/Arduino/epd4in37g/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd4in37g/epdif.h
+++ b/Arduino/epd4in37g/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd5in83/epdif.cpp
+++ b/Arduino/epd5in83/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd5in83/epdif.h
+++ b/Arduino/epd5in83/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd7in3f/epdif.cpp
+++ b/Arduino/epd7in3f/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd7in3f/epdif.h
+++ b/Arduino/epd7in3f/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8

--- a/Arduino/epd7in3g/epdif.cpp
+++ b/Arduino/epd7in3g/epdif.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "epdif.h"
-#include <spi.h>
+#include <SPI.h>
 
 EpdIf::EpdIf() {
 };

--- a/Arduino/epd7in3g/epdif.h
+++ b/Arduino/epd7in3g/epdif.h
@@ -28,7 +28,7 @@
 #ifndef EPDIF_H
 #define EPDIF_H
 
-#include <arduino.h>
+#include <Arduino.h>
 
 // Pin definition
 #define RST_PIN         8


### PR DESCRIPTION
On case-sensitive systems, there is a difference between

#include <arduino.h>

and

#include <Arduino.h>

Fix the source code so that the correct case is used. The same for spi.h -> SPI.h on arduino.

This fixes compilation problems with Arduino IDE on Linux (arduino.h and spi.h: no such file or directory).