### PR TITLE
Optional cleanup

### DIFF
--- a/RaspberryPi_JetsonNano/python/examples/epd_13in3k_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_13in3k_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5_V2.epdconfig.module_exit()
+    epd7in5_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in02_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54.epdconfig.module_exit()
+    epd1in54.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54_V2_test.py
@@ -92,5 +92,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54_V2.epdconfig.module_exit()
+    epd1in54_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54_test.py
@@ -89,5 +89,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54.epdconfig.module_exit()
+    epd1in54.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54b_V2_test.py
@@ -76,5 +76,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54b_V2.epdconfig.module_exit()
+    epd1in54b_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54b_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54b_test.py
@@ -77,5 +77,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54b.epdconfig.module_exit()
+    epd1in54b.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in54c_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in54c_test.py
@@ -74,5 +74,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in54c.epdconfig.module_exit()
+    epd1in54c.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_1in64g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_1in64g_test.py
@@ -66,5 +66,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd1in64g.epdconfig.module_exit()
+    epd1in64g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V2_test.py
@@ -91,5 +91,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13_V2.epdconfig.module_exit()
+    epd2in13_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V3_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V3_test.py
@@ -89,5 +89,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13_V3.epdconfig.module_exit()
+    epd2in13_V3.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_V4_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_V4_test.py
@@ -129,5 +129,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13_V4.epdconfig.module_exit()
+    epd2in13_V4.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13_test.py
@@ -89,5 +89,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13.epdconfig.module_exit()
+    epd2in13.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13b_V3_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13b_V3_test.py
@@ -92,5 +92,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13b_V3.epdconfig.module_exit()
+    epd2in13b_V3.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13b_V4_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13b_V4_test.py
@@ -92,5 +92,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13b_V4.epdconfig.module_exit()
+    epd2in13b_V4.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13bc_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13bc_test.py
@@ -93,5 +93,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13bc.epdconfig.module_exit()
+    epd2in13bc.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13d_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13d_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13d.epdconfig.module_exit()
+    epd2in13d.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in13g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in13g_test.py
@@ -64,5 +64,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in13g.epdconfig.module_exit()
+    epd2in13g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in36g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in36g_test.py
@@ -69,5 +69,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in36g.epdconfig.module_exit()
+    epd2in36g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in66_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in66_test.py
@@ -101,5 +101,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in66.epdconfig.module_exit()
+    epd2in66.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in66b_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in66b_test.py
@@ -93,5 +93,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in66b.epdconfig.module_exit()
+    epd2in66b.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in7_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in7_V2_test.py
@@ -155,5 +155,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in7.epdconfig.module_exit()
+    epd2in7.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in7_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in7_test.py
@@ -109,5 +109,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in7.epdconfig.module_exit()
+    epd2in7.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in7b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in7b_V2_test.py
@@ -99,5 +99,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in7b_V2.epdconfig.module_exit()
+    epd2in7b_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in7b_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in7b_test.py
@@ -99,5 +99,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in7b.epdconfig.module_exit()
+    epd2in7b.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9_V2_test.py
@@ -132,5 +132,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in9_V2.epdconfig.module_exit()
+    epd2in9_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9_test.py
@@ -104,5 +104,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in9.epdconfig.module_exit()
+    epd2in9.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9b_V3_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9b_V3_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in9b_V3.epdconfig.module_exit()
+    epd2in9b_V3.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9bc_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9bc_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in9bc.epdconfig.module_exit()
+    epd2in9bc.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_2in9d_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_2in9d_test.py
@@ -104,5 +104,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd2in9d.epdconfig.module_exit()
+    epd2in9d.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_3in0g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_3in0g_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd3in0g.epdconfig.module_exit()
+    epd3in0g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_3in52_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_3in52_test.py
@@ -115,5 +115,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd3in52.epdconfig.module_exit()
+    epd3in52.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_3in7_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_3in7_test.py
@@ -111,5 +111,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd3in7.epdconfig.module_exit()
+    epd3in7.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in01f_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in01f_test.py
@@ -102,5 +102,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in01f.epdconfig.module_exit()
+    epd4in01f.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in2_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in2_V2_test.py
@@ -179,5 +179,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in2_V2.epdconfig.module_exit()
+    epd4in2_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in2_test.py
@@ -127,5 +127,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in2.epdconfig.module_exit()
+    epd4in2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in2b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in2b_V2_test.py
@@ -97,5 +97,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in2b_V2.epdconfig.module_exit()
+    epd4in2b_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in2bc_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in2bc_test.py
@@ -97,5 +97,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in2bc.epdconfig.module_exit()
+    epd4in2bc.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_4in37g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_4in37g_test.py
@@ -72,5 +72,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd4in37g.epdconfig.module_exit()
+    epd4in37g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_5in65f_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in65f_test.py
@@ -89,5 +89,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in65f.epdconfig.module_exit()
+    epd5in65f.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_5in83_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in83_V2_test.py
@@ -85,5 +85,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in83_V2.epdconfig.module_exit()
+    epd5in83_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_5in83_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in83_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in83.epdconfig.module_exit()
+    epd5in83.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_5in83b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in83b_V2_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in83b_V2.epdconfig.module_exit()
+    epd5in83b_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_5in83bc_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in83bc_test.py
@@ -95,5 +95,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in83bc.epdconfig.module_exit()
+    epd5in83bc.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in3f_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in3f_test.py
@@ -67,5 +67,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in3f.epdconfig.module_exit()
+    epd7in3f.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in3g_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in3g_test.py
@@ -72,5 +72,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in3g.epdconfig.module_exit()
+    epd7in3g.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5_HD_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5_HD_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5_HD.epdconfig.module_exit()
+    epd7in5_HD.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5_V2_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5_V2.epdconfig.module_exit()
+    epd7in5_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5_test.py
@@ -86,5 +86,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5.epdconfig.module_exit()
+    epd7in5.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5b_HD_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5b_HD_test.py
@@ -94,5 +94,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5b_HD.epdconfig.module_exit()
+    epd7in5b_HD.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5b_V2_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5b_V2_test.py
@@ -93,5 +93,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5b_V2.epdconfig.module_exit()
+    epd7in5b_V2.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/examples/epd_7in5bc_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_7in5bc_test.py
@@ -98,5 +98,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd7in5bc.epdconfig.module_exit()
+    epd7in5bc.epdconfig.module_exit(cleanup=True)
     exit()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd13in3k.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd13in3k.py
@@ -178,10 +178,10 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
@@ -333,7 +333,7 @@ class EPD:
         # Set partial refresh
         self.TurnOnDisplay()
 
-    def Sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x50)
         self.send_data(0xf7)
         self.send_command(0x02)
@@ -343,7 +343,7 @@ class EPD:
         epdconfig.delay_ms(200)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54.py
@@ -250,11 +250,11 @@ class EPD:
         # epdconfig.digital_write(self.cs_pin, 1)
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54_V2.py
@@ -306,12 +306,12 @@ class EPD:
                 
         self.TurnOnDisplayPart()
         
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b.py
@@ -201,7 +201,7 @@ class EPD:
         self.send_command(0x12) # DISPLAY_REFRESH
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x50) # VCOM_AND_DATA_INTERVAL_SETTING
         self.send_data(0x17)
         self.send_command(0x82) # to solve Vcom drop 
@@ -216,7 +216,7 @@ class EPD:
         self.send_command(0x02) # power off
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54b_V2.py
@@ -184,12 +184,12 @@ class EPD:
         self.ReadBusy()
 
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) #enter deep sleep
         self.send_data(0x01) 
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in54c.py
@@ -144,13 +144,13 @@ class EPD:
         self.ReadBusy()
 
     #  after this, call epd.init() to awaken the module
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X02)  #  power off
         self.ReadBusy() 
         self.send_command(0X07)  #  deep sleep
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in64g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in64g.py
@@ -227,7 +227,7 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.send_data(0x00)
 
@@ -235,6 +235,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13.py
@@ -215,13 +215,13 @@ class EPD:
                 self.send_data(color)   
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) #enter deep sleep
         self.send_data(0x01)
         epdconfig.delay_ms(100)
          
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
         
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V2.py
@@ -302,7 +302,7 @@ class EPD:
                 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         # self.send_command(0x22) #POWER OFF
         # self.send_data(0xC3)
         # self.send_command(0x20)
@@ -310,7 +310,7 @@ class EPD:
         self.send_command(0x10) #enter deep sleep
         self.send_data(0x03)
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V3.py
@@ -376,12 +376,12 @@ class EPD:
     function : Enter sleep mode
     parameter:
     '''
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) #enter deep sleep
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V4.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V4.py
@@ -339,12 +339,12 @@ class EPD:
     function : Enter sleep mode
     parameter:
     '''
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) #enter deep sleep
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V3.py
@@ -147,7 +147,7 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50) 
         self.send_data(0xf7)
         self.send_command(0X02) 
@@ -156,6 +156,6 @@ class EPD:
         self.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py
@@ -193,11 +193,11 @@ class EPD:
         self.clear()
 
     # sleep
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP
         self.send_data(0x01) # check code
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13bc.py
@@ -150,13 +150,13 @@ class EPD:
         self.send_command(0x12) # REFRESH
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
@@ -358,7 +358,7 @@ class EPD:
         self.SetFullReg()
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50)
         self.send_data(0xf7)
         self.send_command(0X02) # power off
@@ -366,7 +366,7 @@ class EPD:
         self.send_data(0xA5)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13g.py
@@ -228,7 +228,7 @@ class EPD:
                     self.send_data(color)
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         epdconfig.delay_ms(100)
@@ -237,6 +237,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in36g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in36g.py
@@ -227,7 +227,7 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.send_data(0x00)
 
@@ -235,6 +235,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66.py
@@ -230,12 +230,12 @@ class EPD:
         self.turnon_display()
 
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in66b.py
@@ -184,12 +184,12 @@ class EPD:
         self.turnon_display()
 
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7.py
@@ -514,7 +514,7 @@ class EPD:
         self.send_command(0x12) 
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50)
         self.send_data(0xf7)
         self.send_command(0X02)
@@ -522,6 +522,6 @@ class EPD:
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7_V2.py
@@ -509,11 +509,11 @@ class EPD:
         
         self.TurnOnDisplay_4GRAY()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X10)
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b.py
@@ -259,7 +259,7 @@ class EPD:
         self.send_command(0x12) 
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50)
         self.send_data(0xf7)
         self.send_command(0X02)
@@ -267,6 +267,6 @@ class EPD:
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in7b_V2.py
@@ -183,11 +183,11 @@ class EPD:
         self.ReadBusy()
 
     # Enter sleep mode
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10)
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9.py
@@ -194,11 +194,11 @@ class EPD:
                 self.send_data(color)   
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
@@ -462,11 +462,11 @@ class EPD:
         self.send_data2([color] * int(self.height * linewidth)) 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10) # DEEP_SLEEP_MODE
         self.send_data(0x01)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9b_V3.py
@@ -152,13 +152,13 @@ class EPD:
         epdconfig.delay_ms(200) 
         self.ReadBusy()
         
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X02) # power off
         self.ReadBusy()
         self.send_command(0X07) # deep sleep
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9bc.py
@@ -146,13 +146,13 @@ class EPD:
         self.send_command(0x12)
         self.ReadBusy()
         
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X02) # power off
         self.ReadBusy()
         self.send_command(0X07) # deep sleep
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
@@ -290,7 +290,7 @@ class EPD:
         
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50)
         self.send_data(0xf7)
         self.send_command(0X02)         #power off
@@ -298,7 +298,7 @@ class EPD:
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in0g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in0g.py
@@ -208,7 +208,7 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.send_data(0x00)
 
@@ -216,6 +216,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in52.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in52.py
@@ -449,11 +449,11 @@ class EPD:
         self.lut_GC()
         self.refresh()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X07) # DEEP_SLEEP_MODE
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
@@ -454,12 +454,12 @@ class EPD:
         self.ReadBusy()   
 
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X10) #deep sleep
         self.send_data(0x03)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
@@ -229,11 +229,11 @@ class EPD:
         self.ReadBusyLow()
         # epdconfig.delay_ms(500)
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         # epdconfig.delay_ms(500)
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()   
+        epdconfig.module_exit(cleanup)   
         

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
@@ -666,13 +666,13 @@ class EPD:
         self.send_command(0x12)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02)  # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07)  # DEEP_SLEEP
         self.send_data(0XA5)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2_V2.py
@@ -520,11 +520,11 @@ class EPD:
         self.TurnOnDisplay_4GRAY()
         # pass
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10)  # DEEP_SLEEP
         self.send_data(0x01)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 
 ### END OF FILE ###

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2b_V2.py
@@ -146,7 +146,7 @@ class EPD:
         epdconfig.delay_ms(20)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X50)
         self.send_data(0xf7)		#border floating	
 
@@ -156,6 +156,6 @@ class EPD:
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2bc.py
@@ -139,13 +139,13 @@ class EPD:
         self.send_command(0x12) 
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0xA5) # check code
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in37g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in37g.py
@@ -229,7 +229,7 @@ class EPD:
                 self.send_data(color)
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.send_data(0x00)
 
@@ -237,6 +237,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
@@ -207,11 +207,11 @@ class EPD:
         self.ReadBusyLow()
         epdconfig.delay_ms(500)
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         epdconfig.delay_ms(500)
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
         epdconfig.digital_write(self.reset_pin, 0)
 
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83.py
@@ -190,14 +190,14 @@ class EPD:
         self.send_command(0x12)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
-        
-### END OF FILE ###
+        epdconfig.module_exit(cleanup)
+
+# ## END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py
@@ -163,14 +163,14 @@ class EPD:
         self.send_data2([0x00] * int(self.width * self.height / 8))
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
         
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83b_V2.py
@@ -169,13 +169,13 @@ class EPD:
         epdconfig.delay_ms(200) 
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0X02) # power off
         self.ReadBusy()
         self.send_command(0X07) # deep sleep
         self.send_data(0xA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83bc.py
@@ -191,13 +191,13 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0xA5) # check code
     
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3f.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3f.py
@@ -237,11 +237,11 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3g.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3g.py
@@ -229,7 +229,7 @@ class EPD:
 
         self.TurnOnDisplay()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.send_data(0x00)
 
@@ -237,6 +237,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5.py
@@ -172,7 +172,7 @@ class EPD:
         self.send_command(0x12)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
@@ -180,6 +180,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
@@ -172,11 +172,11 @@ class EPD:
         epdconfig.delay_ms(10);
         self.ReadBusy();
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10);
         self.send_data(0x01);
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py
@@ -165,7 +165,7 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
@@ -173,5 +173,5 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2_fast.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_V2_fast.py
@@ -266,7 +266,7 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
@@ -274,5 +274,5 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_HD.py
@@ -198,11 +198,11 @@ class EPD:
         epdconfig.delay_ms(200);      #!!!The delay here is necessary, 200uS at least!!!     
         self.ReadBusy();
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x10);  	#deep sleep
         self.send_data(0x01);
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
@@ -179,7 +179,7 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
@@ -187,6 +187,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5bc.py
@@ -191,7 +191,7 @@ class EPD:
         epdconfig.delay_ms(100)
         self.ReadBusy()
 
-    def sleep(self):
+    def sleep(self, cleanup=False):
         self.send_command(0x02) # POWER_OFF
         self.ReadBusy()
         
@@ -199,6 +199,6 @@ class EPD:
         self.send_data(0XA5)
         
         epdconfig.delay_ms(2000)
-        epdconfig.module_exit()
+        epdconfig.module_exit(cleanup)
 ### END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -121,12 +121,11 @@ class RaspberryPi:
         self.SPI.close()
 
         logger.debug("close 5V, Module enters 0 power consumption ...")
+        self.GPIO_RST_PIN.off()
+        self.GPIO_DC_PIN.off()
+        self.GPIO_PWR_PIN.off()
         if cleanup:
             logger.debug('closing all GPIO pins')
-            self.GPIO_RST_PIN.off()
-            self.GPIO_DC_PIN.off()
-            self.GPIO_PWR_PIN.off()
-    
             self.GPIO_RST_PIN.close()
             self.GPIO_DC_PIN.close()
             # self.GPIO_CS_PIN.close()
@@ -210,12 +209,12 @@ class JetsonNano:
         self.SPI.SYSFS_software_spi_end()
 
         logger.debug("close 5V, Module enters 0 power consumption ...")
+
+        self.GPIO.output(self.RST_PIN, 0)
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.PWR_PIN, 0)
         if cleanup:
-            logger.debug('closing all GPIO pins')
-            self.GPIO.output(self.RST_PIN, 0)
-            self.GPIO.output(self.DC_PIN, 0)
-            self.GPIO.output(self.PWR_PIN, 0)
-    
+            logger.debug('closing all GPIO pins')    
             self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN, self.PWR_PIN])
 
 
@@ -288,12 +287,12 @@ class SunriseX3:
 
         logger.debug("close 5V, Module enters 0 power consumption ...")
         self.Flag = 0
+        self.GPIO.output(self.RST_PIN, 0)
+        self.GPIO.output(self.DC_PIN, 0)
+        self.GPIO.output(self.PWR_PIN, 0)
+        
         if cleanup:
-            logger.debug('closing all GPIO pins')
-            self.GPIO.output(self.RST_PIN, 0)
-            self.GPIO.output(self.DC_PIN, 0)
-            self.GPIO.output(self.PWR_PIN, 0)
-    
+            logger.debug('closing all GPIO pins')    
             self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -107,22 +107,26 @@ class RaspberryPi:
         self.SPI.mode = 0b00
         return 0
 
-    def module_exit(self):
+    def module_exit(self, cleanup=False):
+        ''''''
         logger.debug("spi end")
         self.SPI.close()
 
-        
-        self.GPIO_RST_PIN.off()
-        self.GPIO_DC_PIN.off()
-        self.GPIO_PWR_PIN.off()
-
-        self.GPIO_RST_PIN.close()
-        self.GPIO_DC_PIN.close()
-        # self.GPIO_CS_PIN.close()
-        self.GPIO_PWR_PIN.close()
-        self.GPIO_BUSY_PIN.close()
-
         logger.debug("close 5V, Module enters 0 power consumption ...")
+        if cleanup:
+            logger.debug('closing all GPIO pins')
+            self.GPIO_RST_PIN.off()
+            self.GPIO_DC_PIN.off()
+            self.GPIO_PWR_PIN.off()
+    
+            self.GPIO_RST_PIN.close()
+            self.GPIO_DC_PIN.close()
+            # self.GPIO_CS_PIN.close()
+            self.GPIO_PWR_PIN.close()
+            self.GPIO_BUSY_PIN.close()
+    
+
+# -
 
 
 
@@ -183,16 +187,18 @@ class JetsonNano:
         self.SPI.SYSFS_software_spi_begin()
         return 0
 
-    def module_exit(self):
+    def module_exit(self, cleanup=False):
         logger.debug("spi end")
         self.SPI.SYSFS_software_spi_end()
 
         logger.debug("close 5V, Module enters 0 power consumption ...")
-        self.GPIO.output(self.RST_PIN, 0)
-        self.GPIO.output(self.DC_PIN, 0)
-        self.GPIO.output(self.PWR_PIN, 0)
-
-        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN, self.PWR_PIN])
+        if cleanup:
+            logger.debug('closing all GPIO pins')
+            self.GPIO.output(self.RST_PIN, 0)
+            self.GPIO.output(self.DC_PIN, 0)
+            self.GPIO.output(self.PWR_PIN, 0)
+    
+            self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN, self.PWR_PIN])
 
 
 class SunriseX3:
@@ -249,17 +255,19 @@ class SunriseX3:
         else:
             return 0
 
-    def module_exit(self):
+    def module_exit(self, cleanup=False):
         logger.debug("spi end")
         self.SPI.close()
 
         logger.debug("close 5V, Module enters 0 power consumption ...")
         self.Flag = 0
-        self.GPIO.output(self.RST_PIN, 0)
-        self.GPIO.output(self.DC_PIN, 0)
-        self.GPIO.output(self.PWR_PIN, 0)
-
-        self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
+        if cleanup:
+            logger.debug('closing all GPIO pins')
+            self.GPIO.output(self.RST_PIN, 0)
+            self.GPIO.output(self.DC_PIN, 0)
+            self.GPIO.output(self.PWR_PIN, 0)
+    
+            self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -108,7 +108,15 @@ class RaspberryPi:
         return 0
 
     def module_exit(self, cleanup=False):
-        ''''''
+        '''close SPI handles and optionally cleanup the GPIO pins
+
+        NOTE: Using `cleanup=True` will render the pins unusable until
+        the program restarts.
+
+        Args:
+            cleanup(bool): When True, close all GPIO pins and shutdown interface
+        
+        '''
         logger.debug("spi end")
         self.SPI.close()
 
@@ -124,7 +132,7 @@ class RaspberryPi:
             # self.GPIO_CS_PIN.close()
             self.GPIO_PWR_PIN.close()
             self.GPIO_BUSY_PIN.close()
-    
+
 
 # -
 
@@ -188,6 +196,16 @@ class JetsonNano:
         return 0
 
     def module_exit(self, cleanup=False):
+        '''close SPI handles and optionally cleanup the GPIO pins
+
+        NOTE: Using `cleanup=True` will render the pins unusable until
+        the program restarts.
+
+        Args:
+            cleanup(bool): When True, close all GPIO pins and shutdown interface
+        
+        '''
+        
         logger.debug("spi end")
         self.SPI.SYSFS_software_spi_end()
 
@@ -256,6 +274,15 @@ class SunriseX3:
             return 0
 
     def module_exit(self, cleanup=False):
+        '''close SPI handles and optionally cleanup the GPIO pins
+
+        NOTE: Using `cleanup=True` will render the pins unusable until
+        the program restarts.
+
+        Args:
+            cleanup(bool): When True, close all GPIO pins and shutdown interface
+        
+        '''
         logger.debug("spi end")
         self.SPI.close()
 
@@ -289,4 +316,4 @@ else:
 for func in [x for x in dir(implementation) if not x.startswith('_')]:
     setattr(sys.modules[__name__], func, getattr(implementation, func))
 
-### END OF FILE ###
+# ## END OF FILE ###


### PR DESCRIPTION
The merge from PR #314 adds pin-cleanup to the `module_exit` method in `epdconfig.py`. This causes the pins to be closed and rendered unusable when the `sleep` method is called from one of the board drivers. This has large down-stream affects and will require a large re-write of any code that depends on the `sleep` API functionality.

This PR provides a backwards-compatible fix that allows existing scripts to continue to use the `sleep` method while also offering a way to clean up pins should the program exit unexpectedly (e.g. keyboard interrupt). The pin cleanup is not needed under [gpiozero as this is handled automatically](https://github.com/waveshareteam/e-Paper/issues/315#issuecomment-1859277492).

gpiozero documentation on pin-cleanup: https://gpiozero.readthedocs.io/en/stable/migrating_from_rpigpio.html#cleanup

The change in this PR is the addition of an argument `cleanup` to the `module_exit` in [`epdconfig.py`](RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py) method. 

```
# backwards compatible call with no pin cleanup:
epd5in83.sleep()

# call that allows final cleanup of pins
epd5in83.sleep(cleanup=True)
```

Practical example:
```
except KeyboardInterrupt:    
    logging.info("ctrl + c:")
    epd5in83.sleep(cleanup=True)
    exit()
```