### PR TITLE
Fix USE_DEV_LIB - USE_LGPIO_LIB ifdef mismatch

### DIFF
--- a/RaspberryPi_JetsonNano/c/lib/Config/DEV_Config.c
+++ b/RaspberryPi_JetsonNano/c/lib/Config/DEV_Config.c
@@ -423,7 +423,7 @@ void DEV_Module_Exit(void)
     DEV_Digital_Write(EPD_PWR_PIN, 0);
 	DEV_Digital_Write(EPD_DC_PIN, 0);
 	DEV_Digital_Write(EPD_RST_PIN, 0);
-#elif USE_DEV_LIB 
+#elif USE_LGPIO_LIB
     DEV_Digital_Write(EPD_CS_PIN, 0);
     DEV_Digital_Write(EPD_PWR_PIN, 0);
 	DEV_Digital_Write(EPD_DC_PIN, 0);


### PR DESCRIPTION
Seems to have happened here: https://github.com/waveshareteam/e-Paper/pull/319/files#diff-37cffbd5c1850db6d0f688706f2b51639c8827417c95cd9dd3150b2ec7f3244e

I can't compile without it.