### PR TITLE
remove unneeded import

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13d.py
@@ -31,7 +31,7 @@
 import logging
 from . import epdconfig
 from PIL import Image
-import RPi.GPIO as GPIO
+
 
 # Display resolution
 EPD_WIDTH       = 104
@@ -368,5 +368,5 @@ class EPD:
         epdconfig.delay_ms(2000)
         epdconfig.module_exit()
 
-### END OF FILE ###
+# ## END OF FILE ###
 

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9d.py
@@ -34,7 +34,7 @@ from distutils.command.build_scripts import build_scripts
 import logging
 from . import epdconfig
 from PIL import Image
-import RPi.GPIO as GPIO
+ 
 
 # Display resolution
 EPD_WIDTH       = 128

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
@@ -31,7 +31,7 @@
 import logging
 from . import epdconfig
 from PIL import Image
-import RPi.GPIO as GPIO
+ 
 
 # Display resolution
 EPD_WIDTH  = 400

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2_V2.py
@@ -31,7 +31,7 @@
 import logging
 from . import epdconfig
 from PIL import Image
-import RPi.GPIO as GPIO
+ 
 
 # Display resolution
 EPD_WIDTH  = 400


### PR DESCRIPTION
This PR resolves issue #313 by removing unneeded imports.

The current implementation is importing RPi.GPIO; this is not necessary as this is done in `epdconfig.py` and is now managed by `gpiozero` instead of `RPI.GPIO`.