### PR TITLE
fix: stopped pulling low the reset pin after entering sleep mode.

### DIFF
--- a/Arduino/epd2in13_V4/epd2in13_V4.cpp
+++ b/Arduino/epd2in13_V4/epd2in13_V4.cpp
@@ -422,8 +422,6 @@ void Epd::Sleep()
     SendCommand(0x10); //enter deep sleep
     SendData(0x01);
     DelayMs(200);
-
-    DigitalWrite(reset_pin, LOW);
 }
 
 /* END OF FILE */


### PR DESCRIPTION
When the reset Pin is pulled low, the shield performs a hardware reset, which stops sleep mode according to the datasheet. Therefore the sleep mode is instantly stopped. The function call to set the reset pin low is removed.