### PR TITLE
Derive settings from provided display dimensions in epd7in5b_V2.py

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5b_V2.py
@@ -109,10 +109,10 @@ class EPD:
         self.send_data(0x0F)        # KW-3f KWR-2F BWROTP-0f BWOTP-1f
 
         self.send_command(0x61)     # tres
-        self.send_data(0x03)        # source 800
-        self.send_data(0x20)
-        self.send_data(0x01)        # gate 480
-        self.send_data(0xE0)
+        self.send_data(self.width%256)        # source 800
+        self.send_data(self.width//256)
+        self.send_data(self.height%256)        # gate 480
+        self.send_data(self.height//256)
 
         self.send_command(0X15)
         self.send_data(0x00)


### PR DESCRIPTION
Currently the display dimensions are precomputed and could be derived from the dimension in the header. This could make adaptations/derivations from this file less error prone