### PR TITLE
Add orange to spectra palette

### DIFF
--- a/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/python/lib/epd13in3E.py
+++ b/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/python/lib/epd13in3E.py
@@ -227,7 +227,7 @@ class EPD():
     def getbuffer(self, image):
         # Create a pallette with the 7 colors supported by the panel
         pal_image = Image.new("P", (1,1))
-        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  0,0,0,  0,0,255,  0,255,0) + (0,0,0)*249)
+        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  255,128,0,  0,0,255,  0,255,0) + (0,0,0)*249)
         # pal_image.putpalette( (0,0,0,  255,255,255,  0,255,0,   0,0,255,  255,0,0,  255,255,0, 255,128,0) + (0,0,0)*249)
 
         # Check if we need to rotate the image

--- a/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in0e.py
+++ b/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in0e.py
@@ -185,7 +185,7 @@ class EPD:
     def getbuffer(self, image):
         # Create a pallette with the 7 colors supported by the panel
         pal_image = Image.new("P", (1,1))
-        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  0,0,0,  0,0,255,  0,255,0) + (0,0,0)*249)
+        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  255,128,0,  0,0,255,  0,255,0) + (0,0,0)*249)
 
         # Check if we need to rotate the image
         imwidth, imheight = image.size

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3e.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3e.py
@@ -180,7 +180,7 @@ class EPD:
     def getbuffer(self, image):
         # Create a pallette with the 7 colors supported by the panel
         pal_image = Image.new("P", (1,1))
-        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  0,0,0,  0,0,255,  0,255,0) + (0,0,0)*249)
+        pal_image.putpalette( (0,0,0,  255,255,255,  255,255,0,  255,0,0,  255,128,0,  0,0,255,  0,255,0) + (0,0,0)*249)
         # pal_image.putpalette( (0,0,0,  255,255,255,  0,255,0,   0,0,255,  255,0,0,  255,255,0, 255,128,0) + (0,0,0)*249)
 
         # Check if we need to rotate the image


### PR DESCRIPTION
I noticed that palette index 4 is skipped for Spectra 6 panels.
https://github.com/waveshareteam/e-Paper/blob/ecdd8cf7bab311e6e290c84c68d474deafb7ca8d/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3e.py#L183
So I tried sending `0x04`, and it turns out they can display orange as well.
![image](https://github.com/user-attachments/assets/401be506-c4ab-498c-9462-16682b8805df)

This fills in the missing slot with orange. I've only done it for python because I'm not as familiar with how the C libraries work.