### PR TITLE
Fix dependencies on raspbian bookworm

### DIFF
--- a/E-paper_Separate_Program/2in13_e-Paper_G/RaspberryPi_JetsonNano/python/setup.py
+++ b/E-paper_Separate_Program/2in13_e-Paper_G/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:

--- a/E-paper_Separate_Program/2in15_e-Paper_B/RaspberryPi_JetsonNano/python/setup.py
+++ b/E-paper_Separate_Program/2in15_e-Paper_B/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:

--- a/E-paper_Separate_Program/2in15_e-Paper_G/RaspberryPi_JetsonNano/python/setup.py
+++ b/E-paper_Separate_Program/2in15_e-Paper_G/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:

--- a/E-paper_Separate_Program/3in52_e-Paper_B/RaspberryPi_JetsonNano/python/setup.py
+++ b/E-paper_Separate_Program/3in52_e-Paper_B/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:

--- a/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/setup.py
+++ b/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:

--- a/RaspberryPi_JetsonNano/python/setup.py
+++ b/RaspberryPi_JetsonNano/python/setup.py
@@ -5,6 +5,8 @@ dependencies = ['Pillow']
 
 if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
     dependencies += ['RPi.GPIO', 'spidev']
+elif os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
+    dependencies += ['rpi-lgpio', 'spidev']
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     dependencies += ['Hobot.GPIO', 'spidev']
 else:


### PR DESCRIPTION
Installing the python module with pip on Raspbian Bookworm causes Jetson.GPIO to be installed because `gpiomem-bcm2835` no longer exists on Bookworm.

`rpi-gpiomem` and [rpi-lgpio](https://github.com/waveform80/rpi-lgpio) are used instead.