### PR TITLE
Simplify detection of Raspberry Pi devices

### DIFF
--- a/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/python/lib/epdconfig.py
+++ b/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/python/lib/epdconfig.py
@@ -30,6 +30,7 @@ import time
 import os
 import logging
 import sys
+import platform
 
 from ctypes import *
 import ctypes
@@ -53,18 +54,19 @@ find_dirs = [
 ]
 spi = None
 for find_dir in find_dirs:
-    val = int(os.popen('getconf LONG_BIT').read())
-    val_1 = os.popen("cat /proc/cpuinfo | grep 'Raspberry Pi 5'").read()
-    if val == 64:
-        if val_1 == "":
-            so_filename = os.path.join(find_dir, 'DEV_Config_64_b.so')
-        else:
+    arch = platform.architecture()[0]
+    with open("/proc/device-tree/model") as f:
+        model = f.read()
+    if arch == "64bit":
+        if "Raspberry Pi 5" in model:
             so_filename = os.path.join(find_dir, 'DEV_Config_64_w.so')
-    else:
-        if val_1 == "":
-            so_filename = os.path.join(find_dir, 'DEV_Config_32_b.so')
         else:
+            so_filename = os.path.join(find_dir, 'DEV_Config_64_b.so')
+    else:
+        if "Raspberry Pi 5" in model:
             so_filename = os.path.join(find_dir, 'DEV_Config_32_w.so')
+        else:
+            so_filename = os.path.join(find_dir, 'DEV_Config_32_b.so')
     if os.path.exists(so_filename):
         spi = CDLL(so_filename)
         break

--- a/E-paper_Separate_Program/2in13_e-Paper_G/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/E-paper_Separate_Program/2in13_e-Paper_G/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,7 +31,6 @@ import os
 import logging
 import sys
 import time
-import subprocess
 
 from ctypes import *
 
@@ -301,15 +300,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if sys.version_info[0] == 2:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE)
-else:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE, text=True)
-output, _ = process.communicate()
-if sys.version_info[0] == 2:
-    output = output.decode(sys.stdout.encoding)
-
-if "Raspberry" in output:
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835') or os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/E-paper_Separate_Program/2in15_e-Paper_G/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/E-paper_Separate_Program/2in15_e-Paper_G/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,7 +31,6 @@ import os
 import logging
 import sys
 import time
-import subprocess
 
 from ctypes import *
 
@@ -301,15 +300,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if sys.version_info[0] == 2:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE)
-else:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE, text=True)
-output, _ = process.communicate()
-if sys.version_info[0] == 2:
-    output = output.decode(sys.stdout.encoding)
-
-if "Raspberry" in output:
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835') or os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/E-paper_Separate_Program/3in52_e-Paper_B/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/E-paper_Separate_Program/3in52_e-Paper_B/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,7 +31,6 @@ import os
 import logging
 import sys
 import time
-import subprocess
 
 from ctypes import *
 
@@ -301,15 +300,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if sys.version_info[0] == 2:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE)
-else:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE, text=True)
-output, _ = process.communicate()
-if sys.version_info[0] == 2:
-    output = output.decode(sys.stdout.encoding)
-
-if "Raspberry" in output:
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835') or os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,7 +31,6 @@ import os
 import logging
 import sys
 import time
-import subprocess
 
 from ctypes import *
 
@@ -301,15 +300,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if sys.version_info[0] == 2:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE)
-else:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE, text=True)
-output, _ = process.communicate()
-if sys.version_info[0] == 2:
-    output = output.decode(sys.stdout.encoding)
-
-if "Raspberry" in output:
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835') or os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()

--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py
@@ -31,7 +31,6 @@ import os
 import logging
 import sys
 import time
-import subprocess
 
 from ctypes import *
 
@@ -301,15 +300,7 @@ class SunriseX3:
         self.GPIO.cleanup([self.RST_PIN, self.DC_PIN, self.CS_PIN, self.BUSY_PIN], self.PWR_PIN)
 
 
-if sys.version_info[0] == 2:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE)
-else:
-    process = subprocess.Popen("cat /proc/cpuinfo | grep Raspberry", shell=True, stdout=subprocess.PIPE, text=True)
-output, _ = process.communicate()
-if sys.version_info[0] == 2:
-    output = output.decode(sys.stdout.encoding)
-
-if "Raspberry" in output:
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835') or os.path.exists('/sys/bus/platform/drivers/rpi-gpiomem'):
     implementation = RaspberryPi()
 elif os.path.exists('/sys/bus/platform/drivers/gpio-x3'):
     implementation = SunriseX3()


### PR DESCRIPTION
Replaces this convoluted method...
https://github.com/waveshareteam/e-Paper/blob/ecdd8cf7bab311e6e290c84c68d474deafb7ca8d/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py#L304-L310

...with a simple check for either `/sys/bus/platform/drivers/gpiomem-bcm2835` or `/sys/bus/platform/drivers/rpi-gpiomem`, as in setup.py.

Similarly, in epdconfig for 13in3E, reads files directly, rather than capturing the output of `cat`.