### PR TITLE
Tweak performance of E-Ink Spectra 6

### DIFF
--- a/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/c/lib/e-Paper/EPD_13in3e.c
+++ b/E-paper_Separate_Program/13.3inch_e-Paper_E/RaspberryPi/c/lib/e-Paper/EPD_13in3e.c
@@ -71,7 +71,10 @@ const UBYTE PWS_V[1] = {
 const UBYTE AN_TM_V[9] = {
 	0xC0, 0x1C, 0x1C, 0xCC, 0xCC, 0xCC, 0x15, 0x15, 0x55
 };
-
+const uint8_t AUTO_V[2][1] = {
+  { 0xA5 }, // performs PON -> DRF -> POF
+  { 0xA7 }  // performs PON -> DRF -> POF -> DSLP
+};
 
 const UBYTE AGID_V[1] = {
 	0x10
@@ -169,8 +172,14 @@ static void EPD_13IN3E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_13IN3E_TurnOnDisplay(void)
 {
+#ifdef AUTO_SEQUENCE
+    EPD_13IN3E_CS_ALL(0);
+    EPD_13IN3E_SPI_Sand(AUTO, AUTO_V[0], sizeof(AUTO_V[0]));
+    EPD_13IN3E_CS_ALL(1);
+#else
     printf("Write PON \r\n");
     EPD_13IN3E_CS_ALL(0);
     EPD_13IN3E_SendCommand(0x04); // POWER_ON
@@ -189,6 +198,7 @@ static void EPD_13IN3E_TurnOnDisplay(void)
     EPD_13IN3E_CS_ALL(0);
     EPD_13IN3E_SPI_Sand(POF, POF_V, sizeof(POF_V));
     EPD_13IN3E_CS_ALL(1);
+#endif
     // EPD_13IN3E_ReadBusyH();
     printf("Display Done!! \r\n");
 }

--- a/E-paper_Separate_Program/13.3inch_e-Paper_E/STM32-F103ZET6/User/e-Paper/EPD_13in3e.c
+++ b/E-paper_Separate_Program/13.3inch_e-Paper_E/STM32-F103ZET6/User/e-Paper/EPD_13in3e.c
@@ -70,7 +70,10 @@ const UBYTE PWS_V[1] = {
 const UBYTE AN_TM_V[9] = {
 	0xC0, 0x1C, 0x1C, 0xCC, 0xCC, 0xCC, 0x15, 0x15, 0x55
 };
-
+const uint8_t AUTO_V[2][1] = {
+  { 0xA5 }, // performs PON -> DRF -> POF
+  { 0xA7 }  // performs PON -> DRF -> POF -> DSLP
+};
 
 const UBYTE AGID_V[1] = {
 	0x10
@@ -170,8 +173,14 @@ static void EPD_13IN3E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_13IN3E_TurnOnDisplay(void)
 {
+#ifdef AUTO_SEQUENCE
+    EPD_13IN3E_CS_ALL(0);
+    EPD_13IN3E_SPI_Sand(AUTO, AUTO_V[0], sizeof(AUTO_V[0]));
+    EPD_13IN3E_CS_ALL(1);
+#else
     printf("Write PON \r\n");
     EPD_13IN3E_CS_ALL(0);
     EPD_13IN3E_SendCommand(0x04); // POWER_ON
@@ -189,6 +198,7 @@ static void EPD_13IN3E_TurnOnDisplay(void)
     EPD_13IN3E_CS_ALL(0);
     EPD_13IN3E_SPI_Sand(POF, POF_V, sizeof(POF_V));
     EPD_13IN3E_CS_ALL(1);
+#endif
     // EPD_13IN3E_ReadBusyH();
     printf("Display Done!! \r\n");
 }

--- a/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in0e.c
+++ b/E-paper_Separate_Program/4inch_e-Paper_E/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in0e.c
@@ -89,27 +89,34 @@ static void EPD_4IN0E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_4IN0E_TurnOnDisplay(void)
 {
-    
-    EPD_4IN0E_SendCommand(0x04); // POWER_ON
+#ifdef AUTO_SEQUENCE
+    EPD_4IN0E_SendCommand(0x17);  // AUTO: AUTO SEQUENCE
+    EPD_4IN0E_SendData(0xA5);     // A5: PON->DRF->POF / A7: PON->DRF->POF->DSLP
+#else
+    EPD_4IN0E_SendCommand(0x04);  // PON: POWER ON
     EPD_4IN0E_ReadBusyH();
     DEV_Delay_ms(200);
 
+#if 0
     //Second setting 
-    EPD_4IN0E_SendCommand(0x06);
+    EPD_4IN0E_SendCommand(0x06);  // BTST: BOOSTER SOFT START (why 2nd time?)
     EPD_4IN0E_SendData(0x6F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x17);
     EPD_4IN0E_SendData(0x27);
     DEV_Delay_ms(200);
+#endif
 
-    EPD_4IN0E_SendCommand(0x12); // DISPLAY_REFRESH
+    EPD_4IN0E_SendCommand(0x12);  // DRF: DISPLAY/DATA REFRESH
     EPD_4IN0E_SendData(0x00);
     EPD_4IN0E_ReadBusyH();
 
-    EPD_4IN0E_SendCommand(0x02); // POWER_OFF
+    EPD_4IN0E_SendCommand(0x02);  // POF: POWER OFF
     EPD_4IN0E_SendData(0X00);
+#endif
     EPD_4IN0E_ReadBusyH();
 }
 
@@ -131,32 +138,32 @@ void EPD_4IN0E_Init(void)
     EPD_4IN0E_SendData(0x09);
     EPD_4IN0E_SendData(0x18);
 
-    EPD_4IN0E_SendCommand(0x01);
+    EPD_4IN0E_SendCommand(0x01);  // PWR: POWER SETTING (REGISTER)
     EPD_4IN0E_SendData(0x3F);
 
-    EPD_4IN0E_SendCommand(0x00);
-    EPD_4IN0E_SendData(0x5F);
-    EPD_4IN0E_SendData(0x69);
+    EPD_4IN0E_SendCommand(0x00);  // PSR: PANEL SETTING (REGISTER)
+    EPD_4IN0E_SendData(0x1F);
 
-    EPD_4IN0E_SendCommand(0x05);
+#if 0
+    EPD_4IN0E_SendCommand(0x05);  // looks like BTST, but 0x05 would be PMES: POWER ON MEASURE CMD
     EPD_4IN0E_SendData(0x40);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x2C);
 
-    EPD_4IN0E_SendCommand(0x08);
+    EPD_4IN0E_SendCommand(0x08);  // looks like BTST, but there is no further BTST on 0x08?
     EPD_4IN0E_SendData(0x6F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x22);
+#endif
 
-    EPD_4IN0E_SendCommand(0x06);
-    EPD_4IN0E_SendData(0x6F);
-    EPD_4IN0E_SendData(0x1F);
-    EPD_4IN0E_SendData(0x17);
-    EPD_4IN0E_SendData(0x17);
+    EPD_4IN0E_SendCommand(0x06);  // BTST: BOOSTER SOFT START
+    EPD_4IN0E_SendData(0x10);
+    EPD_4IN0E_SendData(0x10);
+    EPD_4IN0E_SendData(0x10);
 
-    EPD_4IN0E_SendCommand(0x03);
+    EPD_4IN0E_SendCommand(0x03);  // PFS: POWER OFF SEQUENCE SETTING
     EPD_4IN0E_SendData(0x00);
     EPD_4IN0E_SendData(0x54);
     EPD_4IN0E_SendData(0x00);
@@ -166,22 +173,22 @@ void EPD_4IN0E_Init(void)
     EPD_4IN0E_SendData(0x02);
     EPD_4IN0E_SendData(0x00);
 
-    EPD_4IN0E_SendCommand(0x30);
-    EPD_4IN0E_SendData(0x08);
+    EPD_4IN0E_SendCommand(0x30);  // PLL: PLL CONTROL
+    EPD_4IN0E_SendData(0x07);     // 0x00(slow) - 0x07(fast), >0x08(slow again)
 
-    EPD_4IN0E_SendCommand(0x50);
+    EPD_4IN0E_SendCommand(0x50);  // CDI: VCOM AND DATA INTERVAL SETTING
     EPD_4IN0E_SendData(0x3F);
 
-    EPD_4IN0E_SendCommand(0x61);
-    EPD_4IN0E_SendData(0x01);
+    EPD_4IN0E_SendCommand(0x61);  // TRES: RESOLUTION SETTING
+    EPD_4IN0E_SendData(0x01);     // [0x0190][0x0258] -> displaysize
     EPD_4IN0E_SendData(0x90);
     EPD_4IN0E_SendData(0x02); 
     EPD_4IN0E_SendData(0x58);
 
-    EPD_4IN0E_SendCommand(0xE3);
+    EPD_4IN0E_SendCommand(0xE3);  // PWS: POWER SAVING
     EPD_4IN0E_SendData(0x2F);
 
-    EPD_4IN0E_SendCommand(0x84);
+    EPD_4IN0E_SendCommand(0x84);  // could be T_VCDS?
     EPD_4IN0E_SendData(0x01);
     EPD_4IN0E_ReadBusyH();
 

--- a/E-paper_Separate_Program/4inch_e-Paper_E/STM32-F103ZET6/User/e-Paper/EPD_4in0e.c
+++ b/E-paper_Separate_Program/4inch_e-Paper_E/STM32-F103ZET6/User/e-Paper/EPD_4in0e.c
@@ -89,27 +89,34 @@ static void EPD_4IN0E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_4IN0E_TurnOnDisplay(void)
 {
-    
-    EPD_4IN0E_SendCommand(0x04); // POWER_ON
+#ifdef AUTO_SEQUENCE
+    EPD_4IN0E_SendCommand(0x17);  // AUTO: AUTO SEQUENCE
+    EPD_4IN0E_SendData(0xA5);     // A5: PON->DRF->POF / A7: PON->DRF->POF->DSLP
+#else
+    EPD_4IN0E_SendCommand(0x04);  // PON: POWER ON
     EPD_4IN0E_ReadBusyH();
     DEV_Delay_ms(200);
 
+#if 0
     //Second setting 
-    EPD_4IN0E_SendCommand(0x06);
+    EPD_4IN0E_SendCommand(0x06);  // BTST: BOOSTER SOFT START (why 2nd time?)
     EPD_4IN0E_SendData(0x6F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x17);
     EPD_4IN0E_SendData(0x27);
     DEV_Delay_ms(200);
+#endif
 
-    EPD_4IN0E_SendCommand(0x12); // DISPLAY_REFRESH
+    EPD_4IN0E_SendCommand(0x12);  // DRF: DISPLAY/DATA REFRESH
     EPD_4IN0E_SendData(0x00);
     EPD_4IN0E_ReadBusyH();
 
-    EPD_4IN0E_SendCommand(0x02); // POWER_OFF
+    EPD_4IN0E_SendCommand(0x02);  // POF: POWER OFF
     EPD_4IN0E_SendData(0X00);
+#endif
     EPD_4IN0E_ReadBusyH();
 }
 
@@ -131,32 +138,32 @@ void EPD_4IN0E_Init(void)
     EPD_4IN0E_SendData(0x09);
     EPD_4IN0E_SendData(0x18);
 
-    EPD_4IN0E_SendCommand(0x01);
+    EPD_4IN0E_SendCommand(0x01);  // PWR: POWER SETTING (REGISTER)
     EPD_4IN0E_SendData(0x3F);
 
-    EPD_4IN0E_SendCommand(0x00);
-    EPD_4IN0E_SendData(0x5F);
-    EPD_4IN0E_SendData(0x69);
+    EPD_4IN0E_SendCommand(0x00);  // PSR: PANEL SETTING (REGISTER)
+    EPD_4IN0E_SendData(0x1F);
 
-    EPD_4IN0E_SendCommand(0x05);
+#if 0
+    EPD_4IN0E_SendCommand(0x05);  // looks like BTST, but 0x05 would be PMES: POWER ON MEASURE CMD
     EPD_4IN0E_SendData(0x40);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x2C);
 
-    EPD_4IN0E_SendCommand(0x08);
+    EPD_4IN0E_SendCommand(0x08);  // looks like BTST, but there is no further BTST on 0x08?
     EPD_4IN0E_SendData(0x6F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x1F);
     EPD_4IN0E_SendData(0x22);
+#endif
 
-    EPD_4IN0E_SendCommand(0x06);
-    EPD_4IN0E_SendData(0x6F);
-    EPD_4IN0E_SendData(0x1F);
-    EPD_4IN0E_SendData(0x17);
-    EPD_4IN0E_SendData(0x17);
+    EPD_4IN0E_SendCommand(0x06);  // BTST: BOOSTER SOFT START
+    EPD_4IN0E_SendData(0x10);
+    EPD_4IN0E_SendData(0x10);
+    EPD_4IN0E_SendData(0x10);
 
-    EPD_4IN0E_SendCommand(0x03);
+    EPD_4IN0E_SendCommand(0x03);  // PFS: POWER OFF SEQUENCE SETTING
     EPD_4IN0E_SendData(0x00);
     EPD_4IN0E_SendData(0x54);
     EPD_4IN0E_SendData(0x00);
@@ -166,22 +173,22 @@ void EPD_4IN0E_Init(void)
     EPD_4IN0E_SendData(0x02);
     EPD_4IN0E_SendData(0x00);
 
-    EPD_4IN0E_SendCommand(0x30);
-    EPD_4IN0E_SendData(0x08);
+    EPD_4IN0E_SendCommand(0x30);  // PLL: PLL CONTROL
+    EPD_4IN0E_SendData(0x07);     // 0x00(slow) - 0x07(fast), >0x08(slow again)
 
-    EPD_4IN0E_SendCommand(0x50);
+    EPD_4IN0E_SendCommand(0x50);  // CDI: VCOM AND DATA INTERVAL SETTING
     EPD_4IN0E_SendData(0x3F);
 
-    EPD_4IN0E_SendCommand(0x61);
-    EPD_4IN0E_SendData(0x01);
+    EPD_4IN0E_SendCommand(0x61);  // TRES: RESOLUTION SETTING
+    EPD_4IN0E_SendData(0x01);     // [0x0190][0x0258] -> displaysize
     EPD_4IN0E_SendData(0x90);
     EPD_4IN0E_SendData(0x02); 
     EPD_4IN0E_SendData(0x58);
 
-    EPD_4IN0E_SendCommand(0xE3);
+    EPD_4IN0E_SendCommand(0xE3);  // PWS: POWER SAVING
     EPD_4IN0E_SendData(0x2F);
 
-    EPD_4IN0E_SendCommand(0x84);
+    EPD_4IN0E_SendCommand(0x84);  // could be T_VCDS?
     EPD_4IN0E_SendData(0x01);
     EPD_4IN0E_ReadBusyH();
 

--- a/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_7in3e.c
+++ b/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_7in3e.c
@@ -88,25 +88,32 @@ static void EPD_7IN3E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_7IN3E_TurnOnDisplay(void)
 {
-    
-    EPD_7IN3E_SendCommand(0x04); // POWER_ON
+#ifdef AUTO_SEQUENCE
+    EPD_7IN3E_SendCommand(0x17);  // AUTO: AUTO SEQUENCE
+    EPD_7IN3E_SendData(0xA5);     // A5: PON->DRF->POF / A7: PON->DRF->POF->DSLP
+#else
+    EPD_7IN3E_SendCommand(0x04);  // PON: POWER ON
     EPD_7IN3E_ReadBusyH();
 
+#if 0
     //Second setting 
-    EPD_7IN3E_SendCommand(0x06);
+    EPD_7IN3E_SendCommand(0x06);  // BTST: BOOSTER SOFT START (why 2nd time?)
     EPD_7IN3E_SendData(0x6F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x17);
     EPD_7IN3E_SendData(0x49);
+#endif
 
-    EPD_7IN3E_SendCommand(0x12); // DISPLAY_REFRESH
+    EPD_7IN3E_SendCommand(0x12);  // DRF: DISPLAY/DATA REFRESH
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_ReadBusyH();
     
-    EPD_7IN3E_SendCommand(0x02); // POWER_OFF
+    EPD_7IN3E_SendCommand(0x02);  // POF: POWER OFF
     EPD_7IN3E_SendData(0X00);
+#endif
     EPD_7IN3E_ReadBusyH();
 }
 
@@ -128,60 +135,62 @@ void EPD_7IN3E_Init(void)
     EPD_7IN3E_SendData(0x09);
     EPD_7IN3E_SendData(0x18);
 
-    EPD_7IN3E_SendCommand(0x01);//
+    EPD_7IN3E_SendCommand(0x01);  // PWR: POWER SETTING (REGISTER)
     EPD_7IN3E_SendData(0x3F);
 
-    EPD_7IN3E_SendCommand(0x00);  
-    EPD_7IN3E_SendData(0x5F);
-    EPD_7IN3E_SendData(0x69);
+    EPD_7IN3E_SendCommand(0x00);  // PSR: PANEL SETTING (REGISTER)
+    EPD_7IN3E_SendData(0x1F);
 
-    EPD_7IN3E_SendCommand(0x03);
+    EPD_7IN3E_SendCommand(0x03);  // PFS: POWER OFF SEQUENCE SETTING
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_SendData(0x54);
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_SendData(0x44); 
 
-    EPD_7IN3E_SendCommand(0x05);
+#if 0
+    EPD_7IN3E_SendCommand(0x05);  // looks like BTST, but 0x05 would be PMES: POWER ON MEASURE CMD
     EPD_7IN3E_SendData(0x40);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x2C);
+#endif
 
-    EPD_7IN3E_SendCommand(0x06);
-    EPD_7IN3E_SendData(0x6F);
-    EPD_7IN3E_SendData(0x1F);
-    EPD_7IN3E_SendData(0x17);
-    EPD_7IN3E_SendData(0x49);
+    EPD_7IN3E_SendCommand(0x06);  // BTST: BOOSTER SOFT START
+    EPD_7IN3E_SendData(0x10);
+    EPD_7IN3E_SendData(0x10);
+    EPD_7IN3E_SendData(0x10);
 
-    EPD_7IN3E_SendCommand(0x08);
+#if 0
+    EPD_7IN3E_SendCommand(0x08);  // looks like BTST, but there is no further BTST on 0x08?
     EPD_7IN3E_SendData(0x6F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x22);
+#endif
 
-    EPD_7IN3E_SendCommand(0x30);
-    EPD_7IN3E_SendData(0x03);
+    EPD_7IN3E_SendCommand(0x30);  // PLL: PLL CONTROL
+    EPD_7IN3E_SendData(0x07);     // 0x03 -> slow, 0x07 -> fast
     
-    EPD_7IN3E_SendCommand(0x50);
+    EPD_7IN3E_SendCommand(0x50);  // CDI: VCOM AND DATA INTERVAL SETTING
     EPD_7IN3E_SendData(0x3F);
 
-    EPD_7IN3E_SendCommand(0x60);
+    EPD_7IN3E_SendCommand(0x60);  // TCON: TCON SETTING
     EPD_7IN3E_SendData(0x02);
     EPD_7IN3E_SendData(0x00);
 
-    EPD_7IN3E_SendCommand(0x61);
-    EPD_7IN3E_SendData(0x03);
+    EPD_7IN3E_SendCommand(0x61);  // TRES: RESOLUTION SETTING
+    EPD_7IN3E_SendData(0x03);     // [0x0320][0x01E0] -> displaysize
     EPD_7IN3E_SendData(0x20);
     EPD_7IN3E_SendData(0x01); 
     EPD_7IN3E_SendData(0xE0);
 
-    EPD_7IN3E_SendCommand(0x84);
+    EPD_7IN3E_SendCommand(0x84);  // could be T_VCDS?
     EPD_7IN3E_SendData(0x01);
 
-    EPD_7IN3E_SendCommand(0xE3);
+    EPD_7IN3E_SendCommand(0xE3);  // PWS: POWER SAVING
     EPD_7IN3E_SendData(0x2F);
 
-    EPD_7IN3E_SendCommand(0x04);     //PWR on  
+//    EPD_7IN3E_SendCommand(0x04);  // PON: POWER ON (really wanted here?)
     EPD_7IN3E_ReadBusyH();          //waiting for the electronic paper IC to release the idle signal
 
 }

--- a/STM32/STM32-F103ZET6/User/e-Paper/EPD_7in3e.c
+++ b/STM32/STM32-F103ZET6/User/e-Paper/EPD_7in3e.c
@@ -88,25 +88,32 @@ static void EPD_7IN3E_ReadBusyH(void)
 function :  Turn On Display
 parameter:
 ******************************************************************************/
+#define AUTO_SEQUENCE 1
 static void EPD_7IN3E_TurnOnDisplay(void)
 {
-    
-    EPD_7IN3E_SendCommand(0x04); // POWER_ON
+#ifdef AUTO_SEQUENCE
+    EPD_7IN3E_SendCommand(0x17);  // AUTO: AUTO SEQUENCE
+    EPD_7IN3E_SendData(0xA5);     // A5: PON->DRF->POF / A7: PON->DRF->POF->DSLP
+#else
+    EPD_7IN3E_SendCommand(0x04);  // PON: POWER ON
     EPD_7IN3E_ReadBusyH();
 
+#if 0
     //Second setting 
-    EPD_7IN3E_SendCommand(0x06);
+    EPD_7IN3E_SendCommand(0x06);  // BTST: BOOSTER SOFT START (why 2nd time?)
     EPD_7IN3E_SendData(0x6F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x17);
     EPD_7IN3E_SendData(0x49);
+#endif
 
-    EPD_7IN3E_SendCommand(0x12); // DISPLAY_REFRESH
+    EPD_7IN3E_SendCommand(0x12);  // DRF: DISPLAY/DATA REFRESH
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_ReadBusyH();
     
-    EPD_7IN3E_SendCommand(0x02); // POWER_OFF
+    EPD_7IN3E_SendCommand(0x02);  // POF: POWER OFF
     EPD_7IN3E_SendData(0X00);
+#endif
     EPD_7IN3E_ReadBusyH();
 }
 
@@ -128,60 +135,62 @@ void EPD_7IN3E_Init(void)
     EPD_7IN3E_SendData(0x09);
     EPD_7IN3E_SendData(0x18);
 
-    EPD_7IN3E_SendCommand(0x01);//
+    EPD_7IN3E_SendCommand(0x01);  // PWR: POWER SETTING (REGISTER)
     EPD_7IN3E_SendData(0x3F);
 
-    EPD_7IN3E_SendCommand(0x00);  
-    EPD_7IN3E_SendData(0x5F);
-    EPD_7IN3E_SendData(0x69);
+    EPD_7IN3E_SendCommand(0x00);  // PSR: PANEL SETTING (REGISTER)
+    EPD_7IN3E_SendData(0x1F);
 
-    EPD_7IN3E_SendCommand(0x03);
+    EPD_7IN3E_SendCommand(0x03);  // PFS: POWER OFF SEQUENCE SETTING
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_SendData(0x54);
     EPD_7IN3E_SendData(0x00);
     EPD_7IN3E_SendData(0x44); 
 
-    EPD_7IN3E_SendCommand(0x05);
+#if 0
+    EPD_7IN3E_SendCommand(0x05);  // looks like BTST, but 0x05 would be PMES: POWER ON MEASURE CMD
     EPD_7IN3E_SendData(0x40);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x2C);
+#endif
 
-    EPD_7IN3E_SendCommand(0x06);
-    EPD_7IN3E_SendData(0x6F);
-    EPD_7IN3E_SendData(0x1F);
-    EPD_7IN3E_SendData(0x17);
-    EPD_7IN3E_SendData(0x49);
+    EPD_7IN3E_SendCommand(0x06);  // BTST: BOOSTER SOFT START
+    EPD_7IN3E_SendData(0x10);
+    EPD_7IN3E_SendData(0x10);
+    EPD_7IN3E_SendData(0x10);
 
-    EPD_7IN3E_SendCommand(0x08);
+#if 0
+    EPD_7IN3E_SendCommand(0x08);  // looks like BTST, but there is no further BTST on 0x08?
     EPD_7IN3E_SendData(0x6F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x1F);
     EPD_7IN3E_SendData(0x22);
+#endif
 
-    EPD_7IN3E_SendCommand(0x30);
-    EPD_7IN3E_SendData(0x03);
+    EPD_7IN3E_SendCommand(0x30);  // PLL: PLL CONTROL
+    EPD_7IN3E_SendData(0x07);     // 0x03 -> slow, 0x07 -> fast
     
-    EPD_7IN3E_SendCommand(0x50);
+    EPD_7IN3E_SendCommand(0x50);  // CDI: VCOM AND DATA INTERVAL SETTING
     EPD_7IN3E_SendData(0x3F);
 
-    EPD_7IN3E_SendCommand(0x60);
+    EPD_7IN3E_SendCommand(0x60);  // TCON: TCON SETTING
     EPD_7IN3E_SendData(0x02);
     EPD_7IN3E_SendData(0x00);
 
-    EPD_7IN3E_SendCommand(0x61);
-    EPD_7IN3E_SendData(0x03);
+    EPD_7IN3E_SendCommand(0x61);  // TRES: RESOLUTION SETTING
+    EPD_7IN3E_SendData(0x03);     // [0x0320][0x01E0] -> displaysize
     EPD_7IN3E_SendData(0x20);
     EPD_7IN3E_SendData(0x01); 
     EPD_7IN3E_SendData(0xE0);
 
-    EPD_7IN3E_SendCommand(0x84);
+    EPD_7IN3E_SendCommand(0x84);  // could be T_VCDS?
     EPD_7IN3E_SendData(0x01);
 
-    EPD_7IN3E_SendCommand(0xE3);
+    EPD_7IN3E_SendCommand(0xE3);  // PWS: POWER SAVING
     EPD_7IN3E_SendData(0x2F);
 
-    EPD_7IN3E_SendCommand(0x04);     //PWR on  
+//    EPD_7IN3E_SendCommand(0x04);  // PON: POWER ON (really wanted here?)
     EPD_7IN3E_ReadBusyH();          //waiting for the electronic paper IC to release the idle signal
 
 }


### PR DESCRIPTION
The E-Ink Spectra 6 is likely not the fastest EPD, however it can be tweaked in case on knows the commands and arguments. With a bit of research, I determined the following: Especially the PLL CONTROL setting makes a huge difference, while the AUTO command can speed up the PON->DRF->POF(->DSLP) with pure hardware.

To give an impression, what the PLL CONTROL setting can do:

- E-Ink Spectra 6 - 4.0'
```
  D7 D6 D5 D4 D3 D2 D1 D0
  -  -  -  - [    FRS    ] -> Frame Rate Setting (in Hz)

  0x00 -> 37662ms (= 0x10)
  0x01 -> 30038ms
  0x02 -> 22091ms
  0x03 -> 19083ms (= 0x08 ~ 0x0F)
  0x04 -> 14809ms
  0x05 -> 12887ms
  0x06 -> 11448ms
  0x07 ->  9819ms
```
The default was 0x08 :-(
**With the new setting the 4.0' is below 10 seconds!**

- E-Ink Spectra 6 - 7.3'
```
  D7 D6 D5 D4 D3 D2 D1 D0
  -  -  -  - [    FRS    ] -> Frame Rate Setting (in Hz)

  0x00 -> 25365ms (= 0x10)
  0x01 -> 19863ms
  0x02 -> 14944ms
  0x03 -> 12932ms (= 0x08 ~ 0x0F)
  0x04 -> 10075ms
  0x05 ->  8798ms
  0x06 ->  7832ms
  0x07 ->  6746ms
```
The default was 0x03 :-(
**With the new setting the 7.3' is achieving 6.7 seconds!!!**

- E-Ink Spectra 6 - 13.3'
```
  D7 D6 D5 D4 D3 D2 D1 D0
  -  -  -  - [    FRS    ] -> Frame Rate Setting (in Hz)

  0x00 -> 76357ms (= 0x10)
  0x01 -> 38650ms
  0x02 -> 19681ms (= 0x08 ~ 0x0F) // seems default (compared to timing)
  0x03 -> Picture just dark
  0x04 -> 12789ms, but not always correct
  0x05 -> Picture not finished
  0x06 -> -''-
  0x07 -> not working
```
The default was 0x02 :-)
I guess, in case of the 13.3', the Waveshare adapter solely supplies a 3.3V with ~330mA (if I am not mistaken). That might be insufficient to refresh faster.

In case someone is interested in a much cleaner implementation, that can reach a bit faster speeds: https://codeberg.org/psiegl/E-Ink_Spectra_E6/