### PR TITLE
Fixed bug where error handling called incorrect hardware version

### DIFF
--- a/RaspberryPi_JetsonNano/python/examples/epd_5in79_test.py
+++ b/RaspberryPi_JetsonNano/python/examples/epd_5in79_test.py
@@ -134,5 +134,5 @@ except IOError as e:
     
 except KeyboardInterrupt:    
     logging.info("ctrl + c:")
-    epd5in83b_V2.epdconfig.module_exit(cleanup=True)
+    epd5in79.epdconfig.module_exit(cleanup=True)
     exit()


### PR DESCRIPTION
Keyboard Interrupt would call the cleanup function for the incorrect hardware (5.83" b V2) instead of 5.79". Now works correctly. 