### PR TITLE
fix: epd2in13_V4 displayPartial ghosting due to missing 0x26 buffer update

### DIFF
--- a/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V4.py
+++ b/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13_V4.py
@@ -45,6 +45,7 @@ class EPD:
         self.cs_pin = epdconfig.CS_PIN
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
+        self._prev_buffer: bytearray | list | None = None  # Reference buffer for differential partial refresh
         
     '''
     function :Hardware reset
@@ -267,8 +268,11 @@ class EPD:
     '''
     def display(self, image):
         self.send_command(0x24)
-        self.send_data2(image)  
+        self.send_data2(image)
+        self.send_command(0x26)
+        self.send_data2(image)
         self.TurnOnDisplay()
+        self._prev_buffer = image  # Keep buffer in sync
     
     '''
     function : Sends the image buffer in RAM to e-Paper and fast displays
@@ -277,8 +281,11 @@ class EPD:
     '''
     def display_fast(self, image):
         self.send_command(0x24)
-        self.send_data2(image) 
+        self.send_data2(image)
+        self.send_command(0x26)
+        self.send_data2(image)
         self.TurnOnDisplay_Fast()
+        self._prev_buffer = image  # Keep buffer in sync
     '''
     function : Sends the image buffer in RAM to e-Paper and partial refresh
     parameter:
@@ -303,9 +310,15 @@ class EPD:
         self.SetWindow(0, 0, self.width - 1, self.height - 1)
         self.SetCursor(0, 0)
         
-        self.send_command(0x24) # WRITE_RAM
-        self.send_data2(image)  
+        self.send_command(0x26) # Write previous image to RAM for differential refresh
+        prev = self._prev_buffer if self._prev_buffer is not None else image
+        self.send_data2(prev)
+
+        self.send_command(0x24) # Write new image to RAM
+        self.send_data2(image)
+
         self.TurnOnDisplayPart()
+        self._prev_buffer = image  # Save for next partial refresh
 
     '''
     function : Refresh a base image
@@ -319,6 +332,7 @@ class EPD:
         self.send_command(0x26)
         self.send_data2(image)  
         self.TurnOnDisplay()
+        self._prev_buffer = image  # Keep buffer in sync
     
     '''
     function : Clear screen
@@ -334,6 +348,7 @@ class EPD:
         self.send_command(0x24)
         self.send_data2([color] * int(self.height * linewidth))  
         self.TurnOnDisplay()
+        self._prev_buffer = [color] * int(self.height * linewidth)  # Keep buffer in sync
 
     '''
     function : Enter sleep mode


### PR DESCRIPTION
## Problem

When using `displayPartial()` on the `epd2in13_V4` (Waveshare 2.13 v4), visible ghosting and noise artifacts appear on every partial refresh. Previously displayed content "bleeds through" the new image, making the display unreadable over time.

This also occurs on the first partial refresh following a full refresh via `display()` or `display_fast()`.

## Root Cause

`displayPartial()` only writes to the `0x24` RAM buffer (new image) but never updates the `0x26` buffer (previous image reference). The display controller uses `0x26` as a reference to determine which pixels have changed and need to be flipped. Without a valid reference, the controller applies the partial waveform incorrectly, causing the ghosting artifacts.

Similarly, `display()` and `display_fast()` only write to `0x24`, leaving `0x26` out of sync after a full refresh.

## Fix

- Declare `_prev_buffer` in `__init__` to track the last displayed image
- In `display()` and `display_fast()`: write image to both `0x24` and `0x26`
- In `displayPartial()`: write `_prev_buffer` to `0x26` before writing the
  new image to `0x24`, then update `_prev_buffer`
- In `displayPartBaseImage()` and `Clear()`: keep `_prev_buffer` in sync

## Testing

Tested on Raspberry Pi Zero W with epd2in13_V4 (Waveshare 2.13 v4 HAT):
- Partial refresh every second over several minutes: no ghosting
- Clear followed by displayPartial: no ghosting
- display (full refresh) followed by displayPartial: no ghosting